### PR TITLE
Support multiple RSVP responses

### DIFF
--- a/scripts/rsvp.js
+++ b/scripts/rsvp.js
@@ -14,7 +14,18 @@ $('#rsvpForm').submit((event) => {
     $('#rsvpFailureFlashContainer').css('max-height', '500px');
     // eslint-disable-next-line no-console
     console.error(error);
-  }).always(() => {
     $('#rsvpSubmitButton').attr('disabled', false);
   });
 });
+
+$('#addGuestButton').click((event) => {
+  event.preventDefault();
+
+  $('#additionalGuests').append(`
+    <label class="form-label">
+      <input type="text" class="form-control" name="guestName" placeholder="Other guest's name" required>
+    </label>
+  `);
+});
+
+$('#addGuestButton').attr('href', '');

--- a/styles/main.css
+++ b/styles/main.css
@@ -71,10 +71,6 @@ a {
   padding-bottom: 0.6em;
 }
 
-.form-label:last-child {
-  padding-bottom: 0;
-}
-
 .form-control {
   background-color: white;
   border-radius: 0.3em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,6 +53,15 @@
           Guest Name
           <input type="text" class="form-control" name="guestName" placeholder="Your name" required>
         </label>
+        {{#if query.showGuestRsvp}}
+          <label class="form-label">
+            Other Guest Name
+            <input type="text" class="form-control" name="guestName" placeholder="Your +1's name" required>
+          </label>
+        {{else}}
+          <div id="additionalGuests"></div>
+          <a href="/?showGuestRsvp=true" id="addGuestButton" class="form-label">Responding for more than one person?</a>
+        {{/if}}
         <label class="form-label">
           Are You Able To Attend?
           <select class="select form-control" name="attending">

--- a/test/server.js
+++ b/test/server.js
@@ -74,6 +74,30 @@ describe('Server', () => {
           done();
         });
       });
+
+      describe('when responding with multiple guests', () => {
+        it('should store a response for each guest', (done) => {
+          server.inject({
+            method: 'POST',
+            url: '/api/rsvp',
+            payload: {
+              attending: 'yes',
+              guestName: ['Guest One', 'Guest Two'],
+              allergies: 'Some',
+            },
+          }).then(() => {
+            assert(pgClient.query.calledWith(
+              'INSERT INTO guests(name, response, allergies) VALUES($1, $2, $3)',
+              ['Guest One', true, 'Some'],
+            ));
+            assert(pgClient.query.calledWith(
+              'INSERT INTO guests(name, response, allergies) VALUES($1, $2, $3)',
+              ['Guest Two', true, 'Some'],
+            ));
+            done();
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Guests can now respond on behalf of multiple people. If a guest does not
have javascript enabled they can enter responses for a maximum of two
people.

Some of the styling (around the last child of form-labels) was
unnecessary and actually unused, and was harmful when appending
additional guest name inputs.

Additionally guests should ideally not be able to re-submit valid data,
so the submit button is disabled when submitting a response and is not
re-enabled unless something goes wrong.

Fixes #20